### PR TITLE
org.briarproject.Briar.yaml: add access to ~/.briar

### DIFF
--- a/org.briarproject.Briar.yaml
+++ b/org.briarproject.Briar.yaml
@@ -12,6 +12,7 @@ finish-args:
   - --share=network
   # I'll suggest to use XDG_CONFIG_HOME
   - --persist=~/.briar
+  - --filesystem=~/.briar:create
   - --filesystem=xdg-download
   - --env=PATH=/usr/bin:/app/bin:/app/jre/bin
   - --env=JAVA_HOME=/app/jre


### PR DESCRIPTION
Resolves: #5

I think this is a poor practice and proper solution would be having the
flatpak write to ~/.var/app/org.briarproject.Briar/ instead