### PR TITLE
Switch to GNOME runtime & enable notification access

### DIFF
--- a/org.briarproject.Briar.desktop
+++ b/org.briarproject.Briar.desktop
@@ -8,6 +8,7 @@ Icon=briar
 TryExec=briar
 Exec=briar %f
 Terminal=false
+X-GNOME-UsesNotifications=true
 # Category entry according to:
 # https://specifications.freedesktop.org/menu-spec/menu-spec-1.0.html
 Categories=Network;Chat;P2P;InstantMessaging

--- a/org.briarproject.Briar.yaml
+++ b/org.briarproject.Briar.yaml
@@ -1,6 +1,6 @@
 app-id: org.briarproject.Briar
-runtime: org.freedesktop.Platform
-runtime-version: '22.08'
+runtime: org.gnome.Platform
+runtime-version: '43'
 sdk: org.freedesktop.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.openjdk17
@@ -17,6 +17,8 @@ finish-args:
   - --env=PATH=/usr/bin:/app/bin:/app/jre/bin
   - --env=JAVA_HOME=/app/jre
   - --device=dri
+  - --talk-name=org.freedesktop.Notifications
+  - --talk-name=org.kde.StatusNotifierWatcher
 
 build-options:
   env:

--- a/org.briarproject.Briar.yaml
+++ b/org.briarproject.Briar.yaml
@@ -1,7 +1,7 @@
 app-id: org.briarproject.Briar
 runtime: org.gnome.Platform
 runtime-version: '43'
-sdk: org.freedesktop.Sdk
+sdk: org.freedesktop.Sdk//22.08
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.openjdk17
 command: briar

--- a/org.briarproject.Briar.yaml
+++ b/org.briarproject.Briar.yaml
@@ -17,8 +17,6 @@ finish-args:
   - --env=PATH=/usr/bin:/app/bin:/app/jre/bin
   - --env=JAVA_HOME=/app/jre
   - --device=dri
-  - --talk-name=org.freedesktop.Notifications
-  - --talk-name=org.kde.StatusNotifierWatcher
 
 build-options:
   env:


### PR DESCRIPTION
I am not sure if this is the proper fix, I am not a developer, but:

* https://docs.flatpak.org/en/latest/available-runtimes.html#gnome says it's based on freedesktop and amongst the things it adds are libnotify.
  * I don't know if it will bloat the Briar flatpak, but I imagine users are likely to have at least one GNOME app installed and thus they would receive the runtime anyway.
  * My other idea was requesting https://github.com/flathub/shared-modules to include libnotify, but I don't know whether it's justified as it exists in the runtime.

The `talk-name`s are based on my speculation at https://github.com/flathub/org.briarproject.Briar/issues/11#issuecomment-1289124493

In case this is a wrong solution, I hope this at least gives inspiration for finding the right solution or isn't just undesired noise.

Resolves: #11