### PR TITLE
Compile Libnotify & enable notification access

### DIFF
--- a/org.briarproject.Briar.yaml
+++ b/org.briarproject.Briar.yaml
@@ -32,10 +32,18 @@ modules:
     buildsystem: meson
     config-opts:
       - -Dman=false
+      - -Dtests=false
+      - -Dintrospection=disabled
+      - -Dgtk_doc=false
+      - -Ddocbook_docs=disabled
     sources:
       - type: archive
         url: https://download.gnome.org/sources/libnotify/0.8/libnotify-0.8.1.tar.xz
         sha256: d033e6d4d6ccbf46a436c31628a4b661b36dca1f5d4174fe0173e274f4e62557
+        x-checker-data:
+          project-id: 13149
+          type: anitya
+          url-template: "https://download.gnome.org/sources/libnotify/$major.$minor/libnotify-$version.tar.xz"
 
   - name: briar-binary
     buildsystem: simple

--- a/org.briarproject.Briar.yaml
+++ b/org.briarproject.Briar.yaml
@@ -17,6 +17,8 @@ finish-args:
   - --env=PATH=/usr/bin:/app/bin:/app/jre/bin
   - --env=JAVA_HOME=/app/jre
   - --device=dri
+  - --talk-name=org.freedesktop.Notifications
+  - --talk-name=org.kde.StatusNotifierWatcher
 
 build-options:
   env:
@@ -26,7 +28,14 @@ modules:
     buildsystem: simple
     build-commands:
       - /usr/lib/sdk/openjdk17/install.sh
-
+  - name: libnotify
+    buildsystem: meson
+    config-opts:
+      - -Dman=false
+    sources:
+      - type: archive
+        url: https://download.gnome.org/sources/libnotify/0.8/libnotify-0.8.1.tar.xz
+        sha256: d033e6d4d6ccbf46a436c31628a4b661b36dca1f5d4174fe0173e274f4e62557
 
   - name: briar-binary
     buildsystem: simple


### PR DESCRIPTION
This is an alternative approach to the same thing #15 solves.

The major difference here is that the smaller SDK can be used.

(Note: At the time of writing, this was not tested locally)