### PR TITLE
Add X-GNOME-UsesNotifications to desktop file

### DIFF
--- a/org.briarproject.Briar.desktop
+++ b/org.briarproject.Briar.desktop
@@ -8,6 +8,7 @@ Icon=briar
 TryExec=briar
 Exec=briar %f
 Terminal=false
+X-GNOME-UsesNotifications=true
 # Category entry according to:
 # https://specifications.freedesktop.org/menu-spec/menu-spec-1.0.html
 Categories=Network;Chat;P2P;InstantMessaging


### PR DESCRIPTION
This helps with the notification center of gnome: https://wiki.gnome.org/Initiatives/GnomeGoals/NotificationSource

This was recommended as a best practice in the flatpak channel on matrix: https://matrix.to/#/!RfXaBjokqHAbzZrgHz:matrix.org/$ltQubAn6XgtaEg9M3AzHLpnN-TGGsxDnazhPr3-sFHQ?via=matrix.org&via=gnome.org&via=kde.org