### PR TITLE
Use runtime version 24.08

### DIFF
--- a/org.briarproject.Briar.yaml
+++ b/org.briarproject.Briar.yaml
@@ -1,6 +1,6 @@
 app-id: org.briarproject.Briar
 runtime: org.freedesktop.Platform
-runtime-version: '22.08'
+runtime-version: '24.08'
 sdk: org.freedesktop.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.openjdk17


### PR DESCRIPTION
Related issue #28 

Tested locally on Ubuntu 24.04-based OS with the Plasma 6.2.3 desktop environment (Wayland). No issues were found.
